### PR TITLE
Migrate file actions for NC 28

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,7 +20,7 @@ and a unified search provider for messages. It also lets you send files to Matte
 	<screenshot>https://raw.githubusercontent.com/nextcloud/integration_mattermost/main/img/screenshot2.jpg</screenshot>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/integration_mattermost/main/img/screenshot3.jpg</screenshot>
 	<dependencies>
-		<nextcloud min-version="26" max-version="28"/>
+		<nextcloud min-version="28" max-version="28"/>
 	</dependencies>
 	<background-jobs>
 		<job>OCA\Mattermost\BackgroundJob\DailySummaryWebhook</job>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@nextcloud/auth": "^2.0.0",
 				"@nextcloud/axios": "^2.0.0",
 				"@nextcloud/dialogs": "^4.0.1",
+				"@nextcloud/event-bus": "^3.1.0",
 				"@nextcloud/files": "^3.0.0-beta.26",
 				"@nextcloud/initial-state": "^2.0.0",
 				"@nextcloud/l10n": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@nextcloud/auth": "^2.0.0",
 				"@nextcloud/axios": "^2.0.0",
 				"@nextcloud/dialogs": "^4.0.1",
+				"@nextcloud/files": "^3.0.0-beta.26",
 				"@nextcloud/initial-state": "^2.0.0",
 				"@nextcloud/l10n": "^2.0.1",
 				"@nextcloud/moment": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"@nextcloud/auth": "^2.0.0",
 		"@nextcloud/axios": "^2.0.0",
 		"@nextcloud/dialogs": "^4.0.1",
+		"@nextcloud/files": "^3.0.0-beta.26",
 		"@nextcloud/initial-state": "^2.0.0",
 		"@nextcloud/l10n": "^2.0.1",
 		"@nextcloud/moment": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"@nextcloud/auth": "^2.0.0",
 		"@nextcloud/axios": "^2.0.0",
 		"@nextcloud/dialogs": "^4.0.1",
+		"@nextcloud/event-bus": "^3.1.0",
 		"@nextcloud/files": "^3.0.0-beta.26",
 		"@nextcloud/initial-state": "^2.0.0",
 		"@nextcloud/l10n": "^2.0.1",

--- a/src/components/SendFilesModal.vue
+++ b/src/components/SendFilesModal.vue
@@ -236,6 +236,7 @@ import { generateUrl } from '@nextcloud/router'
 import { showError } from '@nextcloud/dialogs'
 import MattermostIcon from './icons/MattermostIcon.vue'
 import { humanFileSize, SEND_TYPE } from '../utils.js'
+import { FileType } from '@nextcloud/files'
 
 const STATES = {
 	IN_PROGRESS: 1,
@@ -386,7 +387,7 @@ export default {
 			})
 		},
 		getFilePreviewUrl(fileId, fileType) {
-			if (fileType === 'folder') {
+			if (fileType === FileType.Folder) {
 				return generateUrl('/apps/theming/img/core/filetypes/folder.svg')
 			}
 			return generateUrl('/apps/integration_mattermost/preview?id={fileId}&x=100&y=100', { fileId })

--- a/src/components/SendFilesModal.vue
+++ b/src/components/SendFilesModal.vue
@@ -386,7 +386,7 @@ export default {
 			})
 		},
 		getFilePreviewUrl(fileId, fileType) {
-			if (fileType === 'dir') {
+			if (fileType === 'folder') {
 				return generateUrl('/apps/theming/img/core/filetypes/folder.svg')
 			}
 			return generateUrl('/apps/integration_mattermost/preview?id={fileId}&x=100&y=100', { fileId })

--- a/src/filesplugin.js
+++ b/src/filesplugin.js
@@ -15,26 +15,19 @@ import { generateUrl } from '@nextcloud/router'
 import { showSuccess, showError } from '@nextcloud/dialogs'
 import { translate as t, translatePlural as n } from '@nextcloud/l10n'
 import { oauthConnect, oauthConnectConfirmDialog, gotoSettingsConfirmDialog, SEND_TYPE } from './utils.js'
-import { registerFileAction, Permission, FileType, FileAction, DefaultType } from '@nextcloud/files'
+import {
+	registerFileAction, Permission, FileAction,
+	davGetClient, davGetDefaultPropfind, davResultToNode, davRootPath,
+} from '@nextcloud/files'
+import { subscribe } from '@nextcloud/event-bus'
 import MattermostIcon from '../img/app-dark.svg?raw'
 
 import Vue from 'vue'
 import './bootstrap.js'
 
-const DEBUG = false
-
-function openChannelSelector(files) {
-	OCA.Mattermost.filesToSend = files
-	const modalVue = OCA.Mattermost.MattermostSendModalVue
-	modalVue.updateChannels()
-	modalVue.setFiles([...files])
-	modalVue.showModal()
-}
+const DEBUG = true
 
 if (!OCA.Mattermost) {
-	/**
-	 * @namespace
-	 */
 	OCA.Mattermost = {
 		actionIgnoreLists: [
 			'trashbin',
@@ -42,6 +35,19 @@ if (!OCA.Mattermost) {
 		],
 		filesToSend: [],
 	}
+}
+
+subscribe('files:list:updated', onFilesListUpdated)
+function onFilesListUpdated({ view, folder, contents }) {
+	OCA.Mattermost.currentFileList = { view, folder, contents }
+}
+
+function openChannelSelector(files) {
+	OCA.Mattermost.filesToSend = files
+	const modalVue = OCA.Mattermost.MattermostSendModalVue
+	modalVue.updateChannels()
+	modalVue.setFiles([...files])
+	modalVue.showModal()
 }
 
 const sendMultiAction = new FileAction({
@@ -70,7 +76,7 @@ const sendMultiAction = new FileAction({
 		if (OCA.Mattermost.mattermostConnected) {
 			openChannelSelector(filesToSend)
 		} else if (OCA.Mattermost.oauthPossible) {
-			this.connectToMattermost(filesToSend)
+			connectToMattermost(filesToSend)
 		} else {
 			gotoSettingsConfirmDialog()
 		}
@@ -102,7 +108,7 @@ const sendSingleAction = new FileAction({
 		if (OCA.Mattermost.mattermostConnected) {
 			openChannelSelector(filesToSend)
 		} else if (OCA.Mattermost.oauthPossible) {
-			this.connectToMattermost(filesToSend)
+			connectToMattermost(filesToSend)
 		} else {
 			gotoSettingsConfirmDialog()
 		}
@@ -112,104 +118,87 @@ const sendSingleAction = new FileAction({
 })
 registerFileAction(sendSingleAction)
 
-/*
-(function() {
-	if (!OCA.Mattermost) {
-		OCA.Mattermost = {
-			filesToSend: [],
+function checkIfFilesToSend() {
+	const urlCheckConnection = generateUrl('/apps/integration_mattermost/files-to-send')
+	axios.get(urlCheckConnection)
+		.then((response) => {
+			const fileIdsStr = response.data.file_ids_to_send_after_oauth
+			const currentDir = response.data.current_dir_after_oauth
+			if (fileIdsStr && currentDir) {
+				sendFileIdsAfterOAuth(fileIdsStr, currentDir)
+			} else {
+				if (DEBUG) console.debug('[Mattermost] nothing to send')
+			}
+		})
+		.catch((error) => {
+			console.error(error)
+		})
+}
+
+/**
+ * In case we successfully connected with oauth and got redirected back to files
+ * actually go on with the files that were previously selected
+ *
+ * @param {string} fileIdsStr list of files to send
+ * @param {string} currentDir path to the current dir
+ */
+async function sendFileIdsAfterOAuth(fileIdsStr, currentDir) {
+	if (DEBUG) console.debug('[Mattermost] in sendFileIdsAfterOAuth, fileIdsStr, currentDir', fileIdsStr, currentDir)
+	// this is only true after an OAuth connection initated from a file action
+	if (fileIdsStr) {
+		// get files info
+		const client = davGetClient()
+		const results = await client.getDirectoryContents(`${davRootPath}${currentDir}`, {
+			details: true,
+			// Query all required properties for a Node
+			data: davGetDefaultPropfind(),
+		})
+		const nodes = results.data.map((r) => davResultToNode(r))
+
+		const fileIds = fileIdsStr.split(',')
+		const files = fileIds.map((fid) => {
+			const f = nodes.find((n) => n.fileid === parseInt(fid))
+			if (f) {
+				return {
+					id: f.fileid,
+					name: f.basename,
+					type: f.type,
+					size: f.size,
+				}
+			}
+			return null
+		}).filter((e) => e !== null)
+		if (DEBUG) console.debug('[Mattermost] in sendFileIdsAfterOAuth, after changeDirectory, files:', files)
+		if (files.length) {
+			if (DEBUG) console.debug('[Mattermost] in sendFileIdsAfterOAuth, after changeDirectory, call openChannelSelector')
+			openChannelSelector(files)
 		}
 	}
+}
 
-	OCA.Mattermost.FilesPlugin = {
-		ignoreLists: [
-			'trashbin',
-			'files.public',
-		],
-
-		attach(fileList) {
-			if (DEBUG) console.debug('[Mattermost] begin of attach')
-			if (this.ignoreLists.indexOf(fileList.id) >= 0) {
-				return
+function connectToMattermost(selectedFiles = []) {
+	oauthConnectConfirmDialog(OCA.Mattermost.mattermostUrl).then((result) => {
+		if (result) {
+			if (OCA.Mattermost.usePopup) {
+				oauthConnect(OCA.Mattermost.mattermostUrl, OCA.Mattermost.clientId, null, true)
+					.then((data) => {
+						OCA.Mattermost.mattermostConnected = true
+						openChannelSelector(selectedFiles)
+					})
+			} else {
+				const selectedFilesIds = selectedFiles.map(f => f.id)
+				const currentDirectory = OCA.Mattermost.currentFileList.folder.attributes.filename
+				oauthConnect(
+					OCA.Mattermost.mattermostUrl,
+					OCA.Mattermost.clientId,
+					'files--' + currentDirectory + '--' + selectedFilesIds.join(','),
+				)
 			}
+		}
+	})
+}
 
-			if (DEBUG) console.debug('[Mattermost] before checkIfFilesToSend')
-			this.checkIfFilesToSend(fileList)
-		},
-
-		checkIfFilesToSend(fileList) {
-			const urlCheckConnection = generateUrl('/apps/integration_mattermost/files-to-send')
-			axios.get(urlCheckConnection).then((response) => {
-				const fileIdsStr = response.data.file_ids_to_send_after_oauth
-				const currentDir = response.data.current_dir_after_oauth
-				if (fileIdsStr && currentDir) {
-					this.sendFileIdsAfterOAuth(fileList, fileIdsStr, currentDir)
-				} else {
-					if (DEBUG) console.debug('[Mattermost] nothing to send')
-				}
-			}).catch((error) => {
-				console.error(error)
-			})
-		},
-
-		// In case we successfully connected with oauth and got redirected back to files
-		// actually go on with the files that were previously selected
-		//
-		// @param {object} fileList the one from attach()
-		// @param {string} fileIdsStr list of files to send
-		// @param {string} currentDir path to the current dir
-		sendFileIdsAfterOAuth: (fileList, fileIdsStr, currentDir) => {
-			if (DEBUG) console.debug('[Mattermost] in sendFileIdsAfterOAuth, fileIdsStr, currentDir', fileIdsStr, currentDir)
-			// this is only true after an OAuth connection initated from a file action
-			if (fileIdsStr) {
-				// trick to make sure the file list is loaded (didn't find an event or a good alternative)
-				// force=true to make sure we get a promise
-				fileList.changeDirectory(currentDir, true, true).then(() => {
-					const fileIds = fileIdsStr.split(',')
-					const files = fileIds.map((fid) => {
-						const f = fileList.files.find((e) => e.id === parseInt(fid))
-						if (f) {
-							return {
-								id: f.id,
-								name: f.name,
-								type: f.type,
-								size: f.size,
-							}
-						}
-						return null
-					}).filter((e) => e !== null)
-					if (DEBUG) console.debug('[Mattermost] in sendFileIdsAfterOAuth, after changeDirectory, files:', files)
-					if (files.length) {
-						if (DEBUG) console.debug('[Mattermost] in sendFileIdsAfterOAuth, after changeDirectory, call openChannelSelector')
-						openChannelSelector(files)
-					}
-				})
-			}
-		},
-
-		connectToMattermost: (selectedFiles = []) => {
-			oauthConnectConfirmDialog(OCA.Mattermost.mattermostUrl).then((result) => {
-				if (result) {
-					if (OCA.Mattermost.usePopup) {
-						oauthConnect(OCA.Mattermost.mattermostUrl, OCA.Mattermost.clientId, null, true)
-							.then((data) => {
-								OCA.Mattermost.mattermostConnected = true
-								openChannelSelector(selectedFiles)
-							})
-					} else {
-						const selectedFilesIds = selectedFiles.map(f => f.id)
-						oauthConnect(
-							OCA.Mattermost.mattermostUrl,
-							OCA.Mattermost.clientId,
-							'files--' + OCA.Files.App.fileList._currentDirectory + '--' + selectedFilesIds.join(','),
-						)
-					}
-				}
-			})
-		},
-	}
-
-})()
-*/
+// ///////////////// Network
 
 function sendPublicLinks(channelId, channelName, comment, permission, expirationDate, password) {
 	const req = {
@@ -366,6 +355,8 @@ function sendMessage(channelId, message, remoteFileIds = undefined) {
 	return axios.post(url, req)
 }
 
+// ////////////// Main
+
 // send file modal
 const modalId = 'mattermostSendModal'
 const modalElement = document.createElement('div')
@@ -405,6 +396,6 @@ axios.get(urlCheckConnection).then((response) => {
 })
 
 document.addEventListener('DOMContentLoaded', () => {
-	if (DEBUG) console.debug('[Mattermost] before register files plugin')
-	OC.Plugins.register('OCA.Files.FileList', OCA.Mattermost.FilesPlugin)
+	if (DEBUG) console.debug('[Mattermost] before checkIfFilesToSend')
+	checkIfFilesToSend()
 })

--- a/src/filesplugin.js
+++ b/src/filesplugin.js
@@ -20,7 +20,7 @@ import {
 	davGetClient, davGetDefaultPropfind, davResultToNode, davRootPath,
 } from '@nextcloud/files'
 import { subscribe } from '@nextcloud/event-bus'
-import MattermostIcon from '../img/app-dark.svg?raw'
+import MattermostIcon from '../img/app-dark.svg'
 
 import Vue from 'vue'
 import './bootstrap.js'

--- a/src/filesplugin.js
+++ b/src/filesplugin.js
@@ -25,7 +25,7 @@ import MattermostIcon from '../img/app-dark.svg?raw'
 import Vue from 'vue'
 import './bootstrap.js'
 
-const DEBUG = true
+const DEBUG = false
 
 if (!OCA.Mattermost) {
 	OCA.Mattermost = {
@@ -34,6 +34,7 @@ if (!OCA.Mattermost) {
 			// 'files.public',
 		],
 		filesToSend: [],
+		currentFileList: null,
 	}
 }
 
@@ -122,8 +123,8 @@ function checkIfFilesToSend() {
 	const urlCheckConnection = generateUrl('/apps/integration_mattermost/files-to-send')
 	axios.get(urlCheckConnection)
 		.then((response) => {
-			const fileIdsStr = response.data.file_ids_to_send_after_oauth
-			const currentDir = response.data.current_dir_after_oauth
+			const fileIdsStr = response?.data?.file_ids_to_send_after_oauth
+			const currentDir = response?.data?.current_dir_after_oauth
 			if (fileIdsStr && currentDir) {
 				sendFileIdsAfterOAuth(fileIdsStr, currentDir)
 			} else {
@@ -187,7 +188,7 @@ function connectToMattermost(selectedFiles = []) {
 					})
 			} else {
 				const selectedFilesIds = selectedFiles.map(f => f.id)
-				const currentDirectory = OCA.Mattermost.currentFileList.folder.attributes.filename
+				const currentDirectory = OCA.Mattermost.currentFileList?.folder?.attributes?.filename
 				oauthConnect(
 					OCA.Mattermost.mattermostUrl,
 					OCA.Mattermost.clientId,

--- a/webpack.js
+++ b/webpack.js
@@ -35,4 +35,9 @@ webpackConfig.plugins.push(
 	}),
 )
 
+webpackConfig.module.rules.push({
+	resourceQuery: /raw/,
+	type: 'asset/source',
+})
+
 module.exports = webpackConfig

--- a/webpack.js
+++ b/webpack.js
@@ -36,7 +36,7 @@ webpackConfig.plugins.push(
 )
 
 webpackConfig.module.rules.push({
-	resourceQuery: /raw/,
+	test: /\.svg$/i,
 	type: 'asset/source',
 })
 


### PR DESCRIPTION
Migrate all file actions related stuff to work with NC 28.

This was harder than expected because of the OAuth redirection stuff. If a popup is used, no problem, we don't loose the context. But if no popup is used and we get redirected back to NC, we need to get the information on the files that were previously selected to immediately open the send modal.

Before the redirection we need to store the current directory.
On page load, after the final redirection to NC, we have the list of file IDs (stored on the server side) and we need the names, types and sizes.
* Before, we could access the fileList object
    * We could get the current dir from the fileList
    * We waited for the fileList to load and obtained the file infos from it
* Now, no more access to the fileList object
    * We listen to the `files:list:updated` event (on the event bus) so we know all about the current directory
    * We use the webdav client to get the list of files in the current dir. We get all information on the files we want to send.

We could also store all the files info in the backend before triggering the redirection. I think the webdav solution is more elegant.

PS: This shows most of what's possible with `@nextcloud/files` and can be used as an example to migrate other apps.