### PR TITLE
Prepare v1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 1.0.5 – 2023-11-02
+
+### Changed
+
+- replace NcMultiselect by NcSelect in files modal
+- disable webhooks until Mattermost implements it
+- Drop support for NC < 28
+
+### Fixed
+
+- Migrate to file actions for Nextcloud 28
+- fix modal content width
+
 ## 1.0.4 – 2023-05-10
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<summary>Integration of Mattermost</summary>
 	<description><![CDATA[Mattermost integration provides a dashboard widget displaying your most important notifications
 and a unified search provider for messages. It also lets you send files to Mattermost from Nextcloud Files.]]></description>
-	<version>1.0.4</version>
+	<version>1.0.5</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Mattermost</namespace>


### PR DESCRIPTION
### Changed

- replace NcMultiselect by NcSelect in files modal
- disable webhooks until Mattermost implements it
- Drop support for NC < 28

### Fixed

- Migrate to file actions for Nextcloud 28
- fix modal content width