### PR TITLE
v1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 1.0.7 – 2024-03-13
+
+### Fixed
+
+- Use fallback image for icon urls
+- Update node deps and fixes
+- Update workflows from templates
+
 ## 1.0.6 – 2024-01-17
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<summary>Integration of Mattermost</summary>
 	<description><![CDATA[Mattermost integration provides a dashboard widget displaying your most important notifications
 and a unified search provider for messages. It also lets you send files to Mattermost from Nextcloud Files.]]></description>
-	<version>1.0.6</version>
+	<version>1.0.7</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Mattermost</namespace>


### PR DESCRIPTION
## 1.0.7 – 2024-03-13

### Fixed

- Use fallback image for icon urls
- Update node deps and fixes
- Update workflows from templates

