### PR TITLE
prepare 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2.0.0 – 2024-10-15
+
+### Changed
+
+- Use password confirmation for sensitive admin/pseronal setting values
+
+### Fixed
+
+- Only send Oauth credentials to the right URLs
+
 ## 1.1.1 – 2024-07-26
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<summary>Integration of Mattermost</summary>
 	<description><![CDATA[Mattermost integration provides a dashboard widget displaying your most important notifications
 and a unified search provider for messages. It also lets you send files to Mattermost from Nextcloud Files.]]></description>
-	<version>1.1.1</version>
+	<version>2.0.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Mattermost</namespace>


### PR DESCRIPTION
### Changed

- Use password confirmation for sensitive admin/pseronal setting values

### Fixed

- Only send Oauth credentials to the right URLs