### PR TITLE
[Bug] Replace broken OC.dialogs.message by DialogBuilder 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -207,9 +207,9 @@
 			}
 		},
 		"node_modules/@babel/helper-define-polyfill-provider": {
-			"version": "0.6.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.6.tgz",
-			"integrity": "sha512-mOAsxeeKkUKayvZR3HeTYD/fICpCPLJrU5ZjelT/PA6WHtNDBOE436YiaEUvHN454bRM3CebhDsIpieCc4texA==",
+			"version": "0.6.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
+			"integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -408,24 +408,24 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-			"integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+			"integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/types": "^7.29.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-			"integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+			"integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/types": "^7.29.0"
@@ -1514,9 +1514,9 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.0.tgz",
-			"integrity": "sha512-fNEdfc0yi16lt6IZo2Qxk3knHVdfMYX33czNb4v8yWhemoBhibCpQK/uYHtSKIiO+p/zd3+8fYVXhQdOVV608w==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.2.tgz",
+			"integrity": "sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -1616,9 +1616,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-			"integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -1683,17 +1683,17 @@
 			}
 		},
 		"node_modules/@cacheable/memory": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.7.tgz",
-			"integrity": "sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz",
+			"integrity": "sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@cacheable/utils": "^2.3.3",
-				"@keyv/bigmap": "^1.3.0",
-				"hookified": "^1.14.0",
-				"keyv": "^5.5.5"
+				"@cacheable/utils": "^2.4.0",
+				"@keyv/bigmap": "^1.3.1",
+				"hookified": "^1.15.1",
+				"keyv": "^5.6.0"
 			}
 		},
 		"node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
@@ -1726,14 +1726,14 @@
 			}
 		},
 		"node_modules/@cacheable/utils": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.3.4.tgz",
-			"integrity": "sha512-knwKUJEYgIfwShABS1BX6JyJJTglAFcEU7EXqzTdiGCXur4voqkiJkdgZIQtWNFhynzDWERcTYv/sETMu3uJWA==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.0.tgz",
+			"integrity": "sha512-PeMMsqjVq+bF0WBsxFBxr/WozBJiZKY0rUojuaCoIaKnEl3Ju1wfEwS+SV1DU/cSe8fqHIPiYJFif8T3MVt4cQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"hashery": "^1.3.0",
+				"hashery": "^1.5.0",
 				"keyv": "^5.6.0"
 			}
 		},
@@ -1814,9 +1814,9 @@
 			}
 		},
 		"node_modules/@csstools/css-syntax-patches-for-csstree": {
-			"version": "1.0.27",
-			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.27.tgz",
-			"integrity": "sha512-sxP33Jwg1bviSUXAV43cVYdmjt2TLnLXNqCWl9xmxHawWVjGz/kEbdkr7F9pxJNBN2Mh+dq0crgItbW6tQvyow==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.1.tgz",
+			"integrity": "sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==",
 			"dev": true,
 			"funding": [
 				{
@@ -1829,7 +1829,15 @@
 				}
 			],
 			"license": "MIT-0",
-			"peer": true
+			"peer": true,
+			"peerDependencies": {
+				"css-tree": "^3.2.1"
+			},
+			"peerDependenciesMeta": {
+				"css-tree": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/@csstools/css-tokenizer": {
 			"version": "4.0.0",
@@ -1898,22 +1906,22 @@
 			}
 		},
 		"node_modules/@emnapi/core": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-			"integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
+			"integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"peer": true,
 			"dependencies": {
-				"@emnapi/wasi-threads": "1.1.0",
+				"@emnapi/wasi-threads": "1.2.0",
 				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-			"integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
+			"integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -1923,9 +1931,9 @@
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-			"integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+			"integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -2033,9 +2041,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
@@ -2068,28 +2076,28 @@
 			}
 		},
 		"node_modules/@floating-ui/core": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
-			"integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
+			"version": "1.7.5",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+			"integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/utils": "^0.2.10"
+				"@floating-ui/utils": "^0.2.11"
 			}
 		},
 		"node_modules/@floating-ui/dom": {
-			"version": "1.7.5",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
-			"integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+			"integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/core": "^1.7.4",
-				"@floating-ui/utils": "^0.2.10"
+				"@floating-ui/core": "^1.7.5",
+				"@floating-ui/utils": "^0.2.11"
 			}
 		},
 		"node_modules/@floating-ui/utils": {
-			"version": "0.2.10",
-			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-			"integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+			"version": "0.2.11",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+			"integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
 			"license": "MIT"
 		},
 		"node_modules/@humanwhocodes/config-array": {
@@ -2122,9 +2130,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
@@ -2302,15 +2310,15 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-core": {
-			"version": "4.56.10",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.56.10.tgz",
-			"integrity": "sha512-PyAEA/3cnHhsGcdY+AmIU+ZPqTuZkDhCXQ2wkXypdLitSpd6d5Ivxhnq4wa2ETRWFVJGabYynBWxIijOswSmOw==",
+			"version": "4.56.11",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.56.11.tgz",
+			"integrity": "sha512-wThHjzUp01ImIjfCwhs+UnFkeGPFAymwLEkOtenHewaKe2pTP12p6r1UuwikA9NEvNf9Vlck92r8fb8n/MWM5w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@jsonjoy.com/fs-node-builtins": "4.56.10",
-				"@jsonjoy.com/fs-node-utils": "4.56.10",
+				"@jsonjoy.com/fs-node-builtins": "4.56.11",
+				"@jsonjoy.com/fs-node-utils": "4.56.11",
 				"thingies": "^2.5.0"
 			},
 			"engines": {
@@ -2325,16 +2333,16 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-fsa": {
-			"version": "4.56.10",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.56.10.tgz",
-			"integrity": "sha512-/FVK63ysNzTPOnCCcPoPHt77TOmachdMS422txM4KhxddLdbW1fIbFMYH0AM0ow/YchCyS5gqEjKLNyv71j/5Q==",
+			"version": "4.56.11",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.56.11.tgz",
+			"integrity": "sha512-ZYlF3XbMayyp97xEN8ZvYutU99PCHjM64mMZvnCseXkCJXJDVLAwlF8Q/7q/xiWQRsv3pQBj1WXHd9eEyYcaCQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@jsonjoy.com/fs-core": "4.56.10",
-				"@jsonjoy.com/fs-node-builtins": "4.56.10",
-				"@jsonjoy.com/fs-node-utils": "4.56.10",
+				"@jsonjoy.com/fs-core": "4.56.11",
+				"@jsonjoy.com/fs-node-builtins": "4.56.11",
+				"@jsonjoy.com/fs-node-utils": "4.56.11",
 				"thingies": "^2.5.0"
 			},
 			"engines": {
@@ -2349,18 +2357,18 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-node": {
-			"version": "4.56.10",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.56.10.tgz",
-			"integrity": "sha512-7R4Gv3tkUdW3dXfXiOkqxkElxKNVdd8BDOWC0/dbERd0pXpPY+s2s1Mino+aTvkGrFPiY+mmVxA7zhskm4Ue4Q==",
+			"version": "4.56.11",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.56.11.tgz",
+			"integrity": "sha512-D65YrnP6wRuZyEWoSFnBJSr5zARVpVBGctnhie4rCsMuGXNzX7IHKaOt85/Aj7SSoG1N2+/xlNjWmkLvZ2H3Tg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@jsonjoy.com/fs-core": "4.56.10",
-				"@jsonjoy.com/fs-node-builtins": "4.56.10",
-				"@jsonjoy.com/fs-node-utils": "4.56.10",
-				"@jsonjoy.com/fs-print": "4.56.10",
-				"@jsonjoy.com/fs-snapshot": "4.56.10",
+				"@jsonjoy.com/fs-core": "4.56.11",
+				"@jsonjoy.com/fs-node-builtins": "4.56.11",
+				"@jsonjoy.com/fs-node-utils": "4.56.11",
+				"@jsonjoy.com/fs-print": "4.56.11",
+				"@jsonjoy.com/fs-snapshot": "4.56.11",
 				"glob-to-regex.js": "^1.0.0",
 				"thingies": "^2.5.0"
 			},
@@ -2376,9 +2384,9 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-node-builtins": {
-			"version": "4.56.10",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.56.10.tgz",
-			"integrity": "sha512-uUnKz8R0YJyKq5jXpZtkGV9U0pJDt8hmYcLRrPjROheIfjMXsz82kXMgAA/qNg0wrZ1Kv+hrg7azqEZx6XZCVw==",
+			"version": "4.56.11",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.56.11.tgz",
+			"integrity": "sha512-CNmt3a0zMCIhniFLXtzPWuUxXFU+U+2VyQiIrgt/rRVeEJNrMQUABaRbVxR0Ouw1LyR9RjaEkPM6nYpED+y43A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -2394,16 +2402,16 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-node-to-fsa": {
-			"version": "4.56.10",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.56.10.tgz",
-			"integrity": "sha512-oH+O6Y4lhn9NyG6aEoFwIBNKZeYy66toP5LJcDOMBgL99BKQMUf/zWJspdRhMdn/3hbzQsZ8EHHsuekbFLGUWw==",
+			"version": "4.56.11",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.56.11.tgz",
+			"integrity": "sha512-5OzGdvJDgZVo+xXWEYo72u81zpOWlxlbG4d4nL+hSiW+LKlua/dldNgPrpWxtvhgyntmdFQad2UTxFyGjJAGhA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@jsonjoy.com/fs-fsa": "4.56.10",
-				"@jsonjoy.com/fs-node-builtins": "4.56.10",
-				"@jsonjoy.com/fs-node-utils": "4.56.10"
+				"@jsonjoy.com/fs-fsa": "4.56.11",
+				"@jsonjoy.com/fs-node-builtins": "4.56.11",
+				"@jsonjoy.com/fs-node-utils": "4.56.11"
 			},
 			"engines": {
 				"node": ">=10.0"
@@ -2417,14 +2425,14 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-node-utils": {
-			"version": "4.56.10",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.56.10.tgz",
-			"integrity": "sha512-8EuPBgVI2aDPwFdaNQeNpHsyqPi3rr+85tMNG/lHvQLiVjzoZsvxA//Xd8aB567LUhy4QS03ptT+unkD/DIsNg==",
+			"version": "4.56.11",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.56.11.tgz",
+			"integrity": "sha512-JADOZFDA3wRfsuxkT0+MYc4F9hJO2PYDaY66kRTG6NqGX3+bqmKu66YFYAbII/tEmQWPZeHoClUB23rtQM9UPg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@jsonjoy.com/fs-node-builtins": "4.56.10"
+				"@jsonjoy.com/fs-node-builtins": "4.56.11"
 			},
 			"engines": {
 				"node": ">=10.0"
@@ -2438,14 +2446,14 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-print": {
-			"version": "4.56.10",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.56.10.tgz",
-			"integrity": "sha512-JW4fp5mAYepzFsSGrQ48ep8FXxpg4niFWHdF78wDrFGof7F3tKDJln72QFDEn/27M1yHd4v7sKHHVPh78aWcEw==",
+			"version": "4.56.11",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.56.11.tgz",
+			"integrity": "sha512-rnaKRgCRIn8JGTjxhS0JPE38YM3Pj/H7SW4/tglhIPbfKEkky7dpPayNKV2qy25SZSL15oFVgH/62dMZ/z7cyA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@jsonjoy.com/fs-node-utils": "4.56.10",
+				"@jsonjoy.com/fs-node-utils": "4.56.11",
 				"tree-dump": "^1.1.0"
 			},
 			"engines": {
@@ -2460,15 +2468,15 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-snapshot": {
-			"version": "4.56.10",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.56.10.tgz",
-			"integrity": "sha512-DkR6l5fj7+qj0+fVKm/OOXMGfDFCGXLfyHkORH3DF8hxkpDgIHbhf/DwncBMs2igu/ST7OEkexn1gIqoU6Y+9g==",
+			"version": "4.56.11",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.56.11.tgz",
+			"integrity": "sha512-IIldPX+cIRQuUol9fQzSS3hqyECxVpYMJQMqdU3dCKZFRzEl1rkIkw4P6y7Oh493sI7YdxZlKr/yWdzEWZ1wGQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
 				"@jsonjoy.com/buffers": "^17.65.0",
-				"@jsonjoy.com/fs-node-utils": "4.56.10",
+				"@jsonjoy.com/fs-node-utils": "4.56.11",
 				"@jsonjoy.com/json-pack": "^17.65.0",
 				"@jsonjoy.com/util": "^17.65.0"
 			},
@@ -3038,27 +3046,27 @@
 			}
 		},
 		"node_modules/@nextcloud/password-confirmation": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@nextcloud/password-confirmation/-/password-confirmation-6.0.2.tgz",
-			"integrity": "sha512-EQbGiQl8lBZrFUNE6Xp9NeQEVtQdb/mtxk3VfwTnoVzAxghsI5yTWr9xcS5EKANoNjvVlIKtREN+LG2WWxft5A==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/password-confirmation/-/password-confirmation-6.1.0.tgz",
+			"integrity": "sha512-N2ChXDbPcUcQCoAjj1yc65zfc61yiKpdM3qm/y3Y/y//NG7XWNNINwBg85lqJ2SISgmVStpsQ1d0blpFCoQXkQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@nextcloud/auth": "^2.5.3",
 				"@nextcloud/axios": "^2.5.2",
-				"@nextcloud/l10n": "^3.4.0",
-				"@nextcloud/logger": "^3.0.2",
-				"@nextcloud/router": "^3.0.1",
-				"@nextcloud/vue": "^9.1.0",
-				"vue": "^3.5.22"
+				"@nextcloud/l10n": "^3.4.1",
+				"@nextcloud/logger": "^3.0.3",
+				"@nextcloud/router": "^3.1.0",
+				"@nextcloud/vue": "^9.6.0",
+				"vue": "^3.5.30"
 			},
 			"engines": {
 				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}
 		},
 		"node_modules/@nextcloud/paths": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/paths/-/paths-3.0.0.tgz",
-			"integrity": "sha512-+sTfTkIbVUa2Ue3bkz3R7F1mhddvHPOWUxkSNg7Q5dAsimVFBaTRgiBAJmsAag3JPsxyuS8kUgeb0zdEssRdTA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/paths/-/paths-3.1.0.tgz",
+			"integrity": "sha512-vtFYA/kthaUDzu6KejTOL1OwnOy7/yynq5zdB/UBpYacAWjUX5Ddh4OMWx3rEavkBJ9/QGhrFryNJLjNfe8OQA==",
 			"license": "GPL-3.0-or-later",
 			"engines": {
 				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
@@ -3123,13 +3131,13 @@
 			}
 		},
 		"node_modules/@nextcloud/vue": {
-			"version": "9.5.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.5.0.tgz",
-			"integrity": "sha512-CQxBfHhF+Q+2r7RXd+l/eSjttJU8A2JFUyq5VpvjfpIql355kejc8bbNnM1pKgGRGSBuW9qw5Ohx0puzHge10w==",
+			"version": "9.6.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.6.0.tgz",
+			"integrity": "sha512-RZuMnrNwzajx3AbJcGHC49NUORSPHMRbzhHCBlR0Z5N3BvUmy5d7MPVTqsmJXiO5emSCTanJ+rwDeo6HTAX3ng==",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@ckpack/vue-color": "^1.6.0",
-				"@floating-ui/dom": "^1.7.5",
+				"@floating-ui/dom": "^1.7.6",
 				"@nextcloud/auth": "^2.5.3",
 				"@nextcloud/axios": "^2.5.2",
 				"@nextcloud/browser-storage": "^0.5.0",
@@ -3139,14 +3147,14 @@
 				"@nextcloud/l10n": "^3.4.1",
 				"@nextcloud/logger": "^3.0.3",
 				"@nextcloud/router": "^3.1.0",
-				"@nextcloud/sharing": "^0.3.0",
+				"@nextcloud/sharing": "^0.4.0",
 				"@vuepic/vue-datepicker": "^11.0.3",
-				"@vueuse/components": "^14.2.0",
-				"@vueuse/core": "^14.0.0",
+				"@vueuse/components": "^14.2.1",
+				"@vueuse/core": "^14.2.1",
 				"blurhash": "^2.0.5",
 				"clone": "^2.1.2",
 				"debounce": "^3.0.0",
-				"dompurify": "^3.3.1",
+				"dompurify": "^3.3.3",
 				"emoji-mart-vue-fast": "^15.0.5",
 				"escape-html": "^1.0.3",
 				"floating-vue": "^5.2.2",
@@ -3159,6 +3167,7 @@
 				"remark-breaks": "^4.0.0",
 				"remark-parse": "^11.0.0",
 				"remark-rehype": "^11.1.2",
+				"remark-stringify": "^11.0.0",
 				"remark-unlink-protocols": "^1.0.0",
 				"splitpanes": "^4.0.4",
 				"striptags": "^3.2.0",
@@ -3169,50 +3178,11 @@
 				"unist-builder": "^4.0.0",
 				"unist-util-visit": "^5.1.0",
 				"vue": "^3.5.18",
-				"vue-router": "^5.0.2",
+				"vue-router": "^5.0.3",
 				"vue-select": "^4.0.0-beta.6"
 			},
 			"engines": {
 				"node": "^20.11.0 || ^22 || ^24"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@nextcloud/files": {
-			"version": "3.12.2",
-			"resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.12.2.tgz",
-			"integrity": "sha512-vBo8tf3Xh6efiF8CrEo3pKj9AtvAF6RdDGO1XKL65IxV8+UUd9Uxl2lUExHlzoDRRczCqfGfaWfRRaFhYqce5Q==",
-			"license": "AGPL-3.0-or-later",
-			"optional": true,
-			"dependencies": {
-				"@nextcloud/auth": "^2.5.3",
-				"@nextcloud/capabilities": "^1.2.1",
-				"@nextcloud/l10n": "^3.4.1",
-				"@nextcloud/logger": "^3.0.3",
-				"@nextcloud/paths": "^3.0.0",
-				"@nextcloud/router": "^3.1.0",
-				"@nextcloud/sharing": "^0.3.0",
-				"cancelable-promise": "^4.3.1",
-				"is-svg": "^6.1.0",
-				"typescript-event-target": "^1.1.1",
-				"webdav": "^5.8.0"
-			},
-			"engines": {
-				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@nextcloud/sharing": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.3.0.tgz",
-			"integrity": "sha512-kV7qeUZvd1fTKeFyH+W5Qq5rNOqG9rLATZM3U9MBxWXHJs3OxMqYQb8UQ3NYONzsX3zDGJmdQECIGHm1ei2sCA==",
-			"license": "GPL-3.0-or-later",
-			"dependencies": {
-				"@nextcloud/initial-state": "^3.0.0",
-				"is-svg": "^6.1.0"
-			},
-			"engines": {
-				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
-			},
-			"optionalDependencies": {
-				"@nextcloud/files": "^3.12.0"
 			}
 		},
 		"node_modules/@nextcloud/webpack-vue-config": {
@@ -3449,6 +3419,9 @@
 				"arm"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3471,6 +3444,9 @@
 				"arm"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3493,6 +3469,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3515,6 +3494,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3537,6 +3519,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3559,6 +3544,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4101,19 +4089,19 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.2.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
-			"integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+			"integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.16.0"
+				"undici-types": "~7.18.0"
 			}
 		},
 		"node_modules/@types/qs": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
-			"integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+			"integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -4605,6 +4593,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4620,6 +4611,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4635,6 +4629,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4650,6 +4647,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4665,6 +4665,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4680,6 +4683,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4695,6 +4701,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4710,6 +4719,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4808,13 +4820,13 @@
 			}
 		},
 		"node_modules/@vue/compiler-core": {
-			"version": "3.5.28",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.28.tgz",
-			"integrity": "sha512-kviccYxTgoE8n6OCw96BNdYlBg2GOWfBuOW4Vqwrt7mSKWKwFVvI8egdTltqRgITGPsTFYtKYfxIG8ptX2PJHQ==",
+			"version": "3.5.30",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.30.tgz",
+			"integrity": "sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/parser": "^7.29.0",
-				"@vue/shared": "3.5.28",
+				"@vue/shared": "3.5.30",
 				"entities": "^7.0.1",
 				"estree-walker": "^2.0.2",
 				"source-map-js": "^1.2.1"
@@ -4833,74 +4845,68 @@
 			}
 		},
 		"node_modules/@vue/compiler-dom": {
-			"version": "3.5.28",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.28.tgz",
-			"integrity": "sha512-/1ZepxAb159jKR1btkefDP+J2xuWL5V3WtleRmxaT+K2Aqiek/Ab/+Ebrw2pPj0sdHO8ViAyyJWfhXXOP/+LQA==",
+			"version": "3.5.30",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.30.tgz",
+			"integrity": "sha512-eCFYESUEVYHhiMuK4SQTldO3RYxyMR/UQL4KdGD1Yrkfdx4m/HYuZ9jSfPdA+nWJY34VWndiYdW/wZXyiPEB9g==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-core": "3.5.28",
-				"@vue/shared": "3.5.28"
+				"@vue/compiler-core": "3.5.30",
+				"@vue/shared": "3.5.30"
 			}
 		},
 		"node_modules/@vue/compiler-sfc": {
-			"version": "3.5.28",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.28.tgz",
-			"integrity": "sha512-6TnKMiNkd6u6VeVDhZn/07KhEZuBSn43Wd2No5zaP5s3xm8IqFTHBj84HJah4UepSUJTro5SoqqlOY22FKY96g==",
+			"version": "3.5.30",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.30.tgz",
+			"integrity": "sha512-LqmFPDn89dtU9vI3wHJnwaV6GfTRD87AjWpTWpyrdVOObVtjIuSeZr181z5C4PmVx/V3j2p+0f7edFKGRMpQ5A==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/parser": "^7.29.0",
-				"@vue/compiler-core": "3.5.28",
-				"@vue/compiler-dom": "3.5.28",
-				"@vue/compiler-ssr": "3.5.28",
-				"@vue/shared": "3.5.28",
+				"@vue/compiler-core": "3.5.30",
+				"@vue/compiler-dom": "3.5.30",
+				"@vue/compiler-ssr": "3.5.30",
+				"@vue/shared": "3.5.30",
 				"estree-walker": "^2.0.2",
 				"magic-string": "^0.30.21",
-				"postcss": "^8.5.6",
+				"postcss": "^8.5.8",
 				"source-map-js": "^1.2.1"
 			}
 		},
 		"node_modules/@vue/compiler-ssr": {
-			"version": "3.5.28",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.28.tgz",
-			"integrity": "sha512-JCq//9w1qmC6UGLWJX7RXzrGpKkroubey/ZFqTpvEIDJEKGgntuDMqkuWiZvzTzTA5h2qZvFBFHY7fAAa9475g==",
+			"version": "3.5.30",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.30.tgz",
+			"integrity": "sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-dom": "3.5.28",
-				"@vue/shared": "3.5.28"
+				"@vue/compiler-dom": "3.5.30",
+				"@vue/shared": "3.5.30"
 			}
 		},
 		"node_modules/@vue/devtools-api": {
-			"version": "8.0.6",
-			"resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.0.6.tgz",
-			"integrity": "sha512-+lGBI+WTvJmnU2FZqHhEB8J1DXcvNlDeEalz77iYgOdY1jTj1ipSBaKj3sRhYcy+kqA8v/BSuvOz1XJucfQmUA==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.1.0.tgz",
+			"integrity": "sha512-O44X57jjkLKbLEc4OgL/6fEPOOanRJU8kYpCE8qfKlV96RQZcdzrcLI5mxMuVRUeXhHKIHGhCpHacyCk0HyO4w==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/devtools-kit": "^8.0.6"
+				"@vue/devtools-kit": "^8.1.0"
 			}
 		},
 		"node_modules/@vue/devtools-kit": {
-			"version": "8.0.6",
-			"resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.0.6.tgz",
-			"integrity": "sha512-9zXZPTJW72OteDXeSa5RVML3zWDCRcO5t77aJqSs228mdopYj5AiTpihozbsfFJ0IodfNs7pSgOGO3qfCuxDtw==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.0.tgz",
+			"integrity": "sha512-/NZlS4WtGIB54DA/z10gzk+n/V7zaqSzYZOVlg2CfdnpIKdB61bd7JDIMxf/zrtX41zod8E2/bbEBoW/d7x70Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/devtools-shared": "^8.0.6",
+				"@vue/devtools-shared": "^8.1.0",
 				"birpc": "^2.6.1",
 				"hookable": "^5.5.3",
-				"mitt": "^3.0.1",
-				"perfect-debounce": "^2.0.0",
-				"speakingurl": "^14.0.1",
-				"superjson": "^2.2.2"
+				"perfect-debounce": "^2.0.0"
 			}
 		},
 		"node_modules/@vue/devtools-shared": {
-			"version": "8.0.6",
-			"resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.0.6.tgz",
-			"integrity": "sha512-Pp1JylTqlgMJvxW6MGyfTF8vGvlBSCAvMFaDCYa82Mgw7TT5eE5kkHgDvmOGHWeJE4zIDfCpCxHapsK2LtIAJg==",
-			"license": "MIT",
-			"dependencies": {
-				"rfdc": "^1.4.1"
-			}
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.0.tgz",
+			"integrity": "sha512-h8uCb4Qs8UT8VdTT5yjY6tOJ//qH7EpxToixR0xqejR55t5OdISIg7AJ7eBkhBs8iu1qG5gY3QQNN1DF1EelAA==",
+			"license": "MIT"
 		},
 		"node_modules/@vue/eslint-config-typescript": {
 			"version": "13.0.0",
@@ -4929,53 +4935,53 @@
 			}
 		},
 		"node_modules/@vue/reactivity": {
-			"version": "3.5.28",
-			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.28.tgz",
-			"integrity": "sha512-gr5hEsxvn+RNyu9/9o1WtdYdwDjg5FgjUSBEkZWqgTKlo/fvwZ2+8W6AfKsc9YN2k/+iHYdS9vZYAhpi10kNaw==",
+			"version": "3.5.30",
+			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.30.tgz",
+			"integrity": "sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/shared": "3.5.28"
+				"@vue/shared": "3.5.30"
 			}
 		},
 		"node_modules/@vue/runtime-core": {
-			"version": "3.5.28",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.28.tgz",
-			"integrity": "sha512-POVHTdbgnrBBIpnbYU4y7pOMNlPn2QVxVzkvEA2pEgvzbelQq4ZOUxbp2oiyo+BOtiYlm8Q44wShHJoBvDPAjQ==",
+			"version": "3.5.30",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.30.tgz",
+			"integrity": "sha512-e0Z+8PQsUTdwV8TtEsLzUM7SzC7lQwYKePydb7K2ZnmS6jjND+WJXkmmfh/swYzRyfP1EY3fpdesyYoymCzYfg==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/reactivity": "3.5.28",
-				"@vue/shared": "3.5.28"
+				"@vue/reactivity": "3.5.30",
+				"@vue/shared": "3.5.30"
 			}
 		},
 		"node_modules/@vue/runtime-dom": {
-			"version": "3.5.28",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.28.tgz",
-			"integrity": "sha512-4SXxSF8SXYMuhAIkT+eBRqOkWEfPu6nhccrzrkioA6l0boiq7sp18HCOov9qWJA5HML61kW8p/cB4MmBiG9dSA==",
+			"version": "3.5.30",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.30.tgz",
+			"integrity": "sha512-2UIGakjU4WSQ0T4iwDEW0W7vQj6n7AFn7taqZ9Cvm0Q/RA2FFOziLESrDL4GmtI1wV3jXg5nMoJSYO66egDUBw==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/reactivity": "3.5.28",
-				"@vue/runtime-core": "3.5.28",
-				"@vue/shared": "3.5.28",
+				"@vue/reactivity": "3.5.30",
+				"@vue/runtime-core": "3.5.30",
+				"@vue/shared": "3.5.30",
 				"csstype": "^3.2.3"
 			}
 		},
 		"node_modules/@vue/server-renderer": {
-			"version": "3.5.28",
-			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.28.tgz",
-			"integrity": "sha512-pf+5ECKGj8fX95bNincbzJ6yp6nyzuLDhYZCeFxUNp8EBrQpPpQaLX3nNCp49+UbgbPun3CeVE+5CXVV1Xydfg==",
+			"version": "3.5.30",
+			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.30.tgz",
+			"integrity": "sha512-v+R34icapydRwbZRD0sXwtHqrQJv38JuMB4JxbOxd8NEpGLny7cncMp53W9UH/zo4j8eDHjQ1dEJXwzFQknjtQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-ssr": "3.5.28",
-				"@vue/shared": "3.5.28"
+				"@vue/compiler-ssr": "3.5.30",
+				"@vue/shared": "3.5.30"
 			},
 			"peerDependencies": {
-				"vue": "3.5.28"
+				"vue": "3.5.30"
 			}
 		},
 		"node_modules/@vue/shared": {
-			"version": "3.5.28",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.28.tgz",
-			"integrity": "sha512-cfWa1fCGBxrvaHRhvV3Is0MgmrbSCxYTXCSCau2I0a1Xw1N1pHAvkWCiXPRAqjvToILvguNyEwjevUqAuBQWvQ==",
+			"version": "3.5.30",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+			"integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==",
 			"license": "MIT"
 		},
 		"node_modules/@vuepic/vue-datepicker": {
@@ -5327,9 +5333,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -5364,9 +5370,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -5658,9 +5664,9 @@
 			}
 		},
 		"node_modules/asn1.js/node_modules/bn.js": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"version": "4.12.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -5774,9 +5780,9 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.13.5",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-			"integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+			"version": "1.13.6",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+			"integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
 			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.15.11",
@@ -5785,9 +5791,9 @@
 			}
 		},
 		"node_modules/babel-loader": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-10.0.0.tgz",
-			"integrity": "sha512-z8jt+EdS61AMw22nSfoNJAZ0vrtmhPRVi6ghL3rCeRZI8cdNYFiV5xeV3HbE7rlZZNmGH8BVccwWt8/ED0QOHA==",
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-10.1.1.tgz",
+			"integrity": "sha512-JwKSzk2kjIe7mgPK+/lyZ2QAaJcpahNAdM+hgR2HI8D0OJVkdj8Rl6J3kaLYki9pwF7P2iWnD8qVv80Lq1ABtg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -5798,20 +5804,29 @@
 				"node": "^18.20.0 || ^20.10.0 || >=22.0.0"
 			},
 			"peerDependencies": {
-				"@babel/core": "^7.12.0",
+				"@babel/core": "^7.12.0 || ^8.0.0-beta.1",
+				"@rspack/core": "^1.0.0 || ^2.0.0-0",
 				"webpack": ">=5.61.0"
+			},
+			"peerDependenciesMeta": {
+				"@rspack/core": {
+					"optional": true
+				},
+				"webpack": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
-			"version": "0.4.15",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.15.tgz",
-			"integrity": "sha512-hR3GwrRwHUfYwGfrisXPIDP3JcYfBrW7wKE7+Au6wDYl7fm/ka1NEII6kORzxNU556JjfidZeBsO10kYvtV1aw==",
+			"version": "0.4.17",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
+			"integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.28.6",
-				"@babel/helper-define-polyfill-provider": "^0.6.6",
+				"@babel/helper-define-polyfill-provider": "^0.6.8",
 				"semver": "^6.3.1"
 			},
 			"peerDependencies": {
@@ -5819,14 +5834,14 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.0.tgz",
-			"integrity": "sha512-AvDcMxJ34W4Wgy4KBIIePQTAOP1Ie2WFwkQp3dB7FQ/f0lI5+nM96zUnYEOE1P9sEg0es5VCP0HxiWu5fUHZAQ==",
+			"version": "0.14.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
+			"integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.6",
+				"@babel/helper-define-polyfill-provider": "^0.6.8",
 				"core-js-compat": "^3.48.0"
 			},
 			"peerDependencies": {
@@ -5834,14 +5849,14 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-regenerator": {
-			"version": "0.6.6",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.6.tgz",
-			"integrity": "sha512-hYm+XLYRMvupxiQzrvXUj7YyvFFVfv5gI0R71AJzudg1g2AI2vyCPPIFEBjk162/wFzti3inBHo7isWFuEVS/A==",
+			"version": "0.6.8",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
+			"integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.6"
+				"@babel/helper-define-polyfill-provider": "^0.6.8"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -5892,14 +5907,17 @@
 			"peer": true
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.9.19",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-			"integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+			"version": "2.10.8",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
+			"integrity": "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"bin": {
-				"baseline-browser-mapping": "dist/cli.js"
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/batch": {
@@ -5940,9 +5958,9 @@
 			"license": "MIT"
 		},
 		"node_modules/bn.js": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
-			"integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+			"integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -6373,18 +6391,18 @@
 			}
 		},
 		"node_modules/cacheable": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.2.tgz",
-			"integrity": "sha512-w+ZuRNmex9c1TR9RcsxbfTKCjSL0rh1WA5SABbrWprIHeNBdmyQLSYonlDy9gpD+63XT8DgZ/wNh1Smvc9WnJA==",
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.4.tgz",
+			"integrity": "sha512-djgxybDbw9fL/ZWMI3+CE8ZilNxcwFkVtDc1gJ+IlOSSWkSMPQabhV/XCHTQ6pwwN6aivXPZ43omTooZiX06Ew==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@cacheable/memory": "^2.0.7",
-				"@cacheable/utils": "^2.3.3",
+				"@cacheable/memory": "^2.0.8",
+				"@cacheable/utils": "^2.4.0",
 				"hookified": "^1.15.0",
-				"keyv": "^5.5.5",
-				"qified": "^0.6.0"
+				"keyv": "^5.6.0",
+				"qified": "^0.9.0"
 			}
 		},
 		"node_modules/cacheable/node_modules/keyv": {
@@ -6468,9 +6486,9 @@
 			"optional": true
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001770",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
-			"integrity": "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==",
+			"version": "1.0.30001780",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001780.tgz",
+			"integrity": "sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -6886,25 +6904,10 @@
 			"license": "MIT",
 			"peer": true
 		},
-		"node_modules/copy-anything": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
-			"integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
-			"license": "MIT",
-			"dependencies": {
-				"is-what": "^5.2.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mesqueeb"
-			}
-		},
 		"node_modules/core-js": {
-			"version": "3.48.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
-			"integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+			"integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"funding": {
@@ -6913,9 +6916,9 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.48.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
-			"integrity": "sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==",
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+			"integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -6936,9 +6939,9 @@
 			"peer": true
 		},
 		"node_modules/cosmiconfig": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-			"integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+			"integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -6976,9 +6979,9 @@
 			}
 		},
 		"node_modules/create-ecdh/node_modules/bn.js": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"version": "4.12.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -7130,15 +7133,15 @@
 			}
 		},
 		"node_modules/css-tree": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-			"integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"mdn-data": "2.12.2",
-				"source-map-js": "^1.0.1"
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
 			},
 			"engines": {
 				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
@@ -7474,9 +7477,9 @@
 			}
 		},
 		"node_modules/diffie-hellman/node_modules/bn.js": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"version": "4.12.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -7584,9 +7587,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-			"integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+			"integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
@@ -7631,9 +7634,9 @@
 			"peer": true
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.286",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
-			"integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+			"version": "1.5.321",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
+			"integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true
@@ -7656,9 +7659,9 @@
 			}
 		},
 		"node_modules/elliptic/node_modules/bn.js": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"version": "4.12.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -7696,9 +7699,9 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.19.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
-			"integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
+			"version": "5.20.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+			"integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -8268,9 +8271,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-import/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
@@ -8363,9 +8366,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-n/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
@@ -8472,9 +8475,9 @@
 			}
 		},
 		"node_modules/eslint-webpack-plugin": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-5.0.2.tgz",
-			"integrity": "sha512-cB7EO2o+4gPUzK6zxgegSet8uu/hHwzOiG+2976MHWiwWFj9mmPbTrzlW0InFl6hl89S1D9MPKK5F7vNFpZc4g==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-5.0.3.tgz",
+			"integrity": "sha512-P2Id4RMSMQMwMEuw3W9x3n2qDbKPeD+tehWMY3ENFsoSPKNZ9i3WTZEsFE7NeQIpNebhNEGw8qorvpLVq1rK1g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8483,7 +8486,7 @@
 				"jest-worker": "^29.7.0",
 				"micromatch": "^4.0.8",
 				"normalize-path": "^3.0.0",
-				"schema-utils": "^4.3.0"
+				"schema-utils": "^4.3.2"
 			},
 			"engines": {
 				"node": ">= 18.12.0"
@@ -8553,9 +8556,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
@@ -8904,10 +8907,25 @@
 			],
 			"license": "BSD-3-Clause"
 		},
+		"node_modules/fast-xml-builder": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+			"integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"path-expression-matcher": "^1.1.3"
+			}
+		},
 		"node_modules/fast-xml-parser": {
-			"version": "4.5.3",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-			"integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.4.tgz",
+			"integrity": "sha512-jE8ugADnYOBsu1uaoayVl1tVKAMNOXyjwvv2U6udEA2ORBhDooJDWoGxTkhd4Qn4yh59JVVt/pKXtjPwx9OguQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -8918,7 +8936,7 @@
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"strnum": "^1.1.1"
+				"strnum": "^1.0.5"
 			},
 			"bin": {
 				"fxparser": "src/cli/cli.js"
@@ -9094,9 +9112,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -9313,9 +9331,9 @@
 			}
 		},
 		"node_modules/get-east-asian-width": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-			"integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+			"integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -9472,9 +9490,9 @@
 			}
 		},
 		"node_modules/glob/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
@@ -9746,9 +9764,9 @@
 			}
 		},
 		"node_modules/hashery": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/hashery/-/hashery-1.4.0.tgz",
-			"integrity": "sha512-Wn2i1In6XFxl8Az55kkgnFRiAlIAushzh26PTjL2AKtQcEfXrcLa7Hn5QOWGZEf3LU057P9TwwZjFyxfS1VuvQ==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.0.tgz",
+			"integrity": "sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -10157,9 +10175,9 @@
 			}
 		},
 		"node_modules/immutable": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
-			"integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+			"integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -10742,9 +10760,9 @@
 			}
 		},
 		"node_modules/is-network-error": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.0.tgz",
-			"integrity": "sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
+			"integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -10986,18 +11004,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-what": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
-			"integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mesqueeb"
-			}
-		},
 		"node_modules/is-wsl": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
@@ -11212,9 +11218,9 @@
 			"peer": true
 		},
 		"node_modules/launch-editor": {
-			"version": "2.12.0",
-			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.12.0.tgz",
-			"integrity": "sha512-giOHXoOtifjdHqUamwKq6c49GzBdLjvxrd2D+Q4V6uOHopJv7p9VJxikDsQ/CBXZbEITgUqSVHXLTG3VhPP1Dg==",
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.13.1.tgz",
+			"integrity": "sha512-lPSddlAAluRKJ7/cjRFoXUFzaX7q/YKI7yPHuEvSJVqoXvFnJov1/Ud87Aa4zULIbA9Nja4mSPK8l0z/7eV2wA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -11493,9 +11499,9 @@
 			}
 		},
 		"node_modules/mdast-util-from-markdown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
-			"integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+			"integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mdast": "^4.0.0",
@@ -11660,9 +11666,9 @@
 			}
 		},
 		"node_modules/mdn-data": {
-			"version": "2.12.2",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-			"integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
 			"dev": true,
 			"license": "CC0-1.0",
 			"peer": true
@@ -11679,21 +11685,21 @@
 			}
 		},
 		"node_modules/memfs": {
-			"version": "4.56.10",
-			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.56.10.tgz",
-			"integrity": "sha512-eLvzyrwqLHnLYalJP7YZ3wBe79MXktMdfQbvMrVD80K+NhrIukCVBvgP30zTJYEEDh9hZ/ep9z0KOdD7FSHo7w==",
+			"version": "4.56.11",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.56.11.tgz",
+			"integrity": "sha512-/GodtwVeKVIHZKLUSr2ZdOxKBC5hHki4JNCU22DoCGPEHr5o2PD5U721zvESKyWwCfTfavFl9WZYgA13OAYK0g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@jsonjoy.com/fs-core": "4.56.10",
-				"@jsonjoy.com/fs-fsa": "4.56.10",
-				"@jsonjoy.com/fs-node": "4.56.10",
-				"@jsonjoy.com/fs-node-builtins": "4.56.10",
-				"@jsonjoy.com/fs-node-to-fsa": "4.56.10",
-				"@jsonjoy.com/fs-node-utils": "4.56.10",
-				"@jsonjoy.com/fs-print": "4.56.10",
-				"@jsonjoy.com/fs-snapshot": "4.56.10",
+				"@jsonjoy.com/fs-core": "4.56.11",
+				"@jsonjoy.com/fs-fsa": "4.56.11",
+				"@jsonjoy.com/fs-node": "4.56.11",
+				"@jsonjoy.com/fs-node-builtins": "4.56.11",
+				"@jsonjoy.com/fs-node-to-fsa": "4.56.11",
+				"@jsonjoy.com/fs-node-utils": "4.56.11",
+				"@jsonjoy.com/fs-print": "4.56.11",
+				"@jsonjoy.com/fs-snapshot": "4.56.11",
 				"@jsonjoy.com/json-pack": "^1.11.0",
 				"@jsonjoy.com/util": "^1.9.0",
 				"glob-to-regex.js": "^1.0.1",
@@ -11710,9 +11716,9 @@
 			}
 		},
 		"node_modules/meow": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-14.0.0.tgz",
-			"integrity": "sha512-JhC3R1f6dbspVtmF3vKjAWz1EVIvwFrGGPLSdU6rK79xBwHWTuHoLnRX/t1/zHS1Ch1Y2UtIrih7DAHuH9JFJA==",
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
+			"integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -12234,9 +12240,9 @@
 			}
 		},
 		"node_modules/miller-rabin/node_modules/bn.js": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"version": "4.12.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -12293,12 +12299,12 @@
 			"peer": true
 		},
 		"node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -12318,22 +12324,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/mitt": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-			"integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-			"license": "MIT"
-		},
 		"node_modules/mlly": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
-			"integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.1.tgz",
+			"integrity": "sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==",
 			"license": "MIT",
 			"dependencies": {
-				"acorn": "^8.15.0",
+				"acorn": "^8.16.0",
 				"pathe": "^2.0.3",
 				"pkg-types": "^1.3.1",
-				"ufo": "^1.6.1"
+				"ufo": "^1.6.3"
 			}
 		},
 		"node_modules/mlly/node_modules/confbox": {
@@ -12559,9 +12559,9 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.27",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-			"integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+			"version": "2.0.36",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+			"integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -13028,6 +13028,21 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/path-expression-matcher": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
+			"integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -13218,9 +13233,9 @@
 			}
 		},
 		"node_modules/pkijs": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.3.3.tgz",
-			"integrity": "sha512-+KD8hJtqQMYoTuL1bbGOqxb4z+nZkTAwVdNtWwe8Tc2xNbEmdJYIYoc6Qt0uF55e6YW6KuTHw1DjQ18gMhzepw==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+			"integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"peer": true,
@@ -13248,9 +13263,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+			"version": "8.5.8",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -13571,9 +13586,9 @@
 			}
 		},
 		"node_modules/public-encrypt/node_modules/bn.js": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"version": "4.12.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -13612,18 +13627,26 @@
 			}
 		},
 		"node_modules/qified": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/qified/-/qified-0.6.0.tgz",
-			"integrity": "sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==",
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/qified/-/qified-0.9.0.tgz",
+			"integrity": "sha512-4q61YgkHbY6gmwkqm0BsxyLDO3UYdrdiJTJ7JiaZb3xpW1duxn135SB7KqUEkCiuu5O4W+TtwEWP2VjmSRanvA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"hookified": "^1.14.0"
+				"hookified": "^2.1.0"
 			},
 			"engines": {
 				"node": ">=20"
 			}
+		},
+		"node_modules/qified/node_modules/hookified": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/hookified/-/hookified-2.1.0.tgz",
+			"integrity": "sha512-ootKng4eaxNxa7rx6FJv2YKef3DuhqbEj3l70oGXwddPQEEnISm50TEZQclqiLTAtilT2nu7TErtCO523hHkyg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/qs": {
 			"version": "6.15.0",
@@ -14008,6 +14031,21 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/remark-stringify": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+			"integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-to-markdown": "^2.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/remark-unlink-protocols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/remark-unlink-protocols/-/remark-unlink-protocols-1.0.0.tgz",
@@ -14147,12 +14185,6 @@
 				"iojs": ">=1.0.0",
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/rfdc": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-			"integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-			"license": "MIT"
 		},
 		"node_modules/rimraf": {
 			"version": "3.0.2",
@@ -14383,15 +14415,15 @@
 			"peer": true
 		},
 		"node_modules/sass": {
-			"version": "1.97.3",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
-			"integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
+			"version": "1.98.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.98.0.tgz",
+			"integrity": "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"chokidar": "^4.0.0",
-				"immutable": "^5.0.2",
+				"immutable": "^5.1.5",
 				"source-map-js": ">=0.6.2 <2.0.0"
 			},
 			"bin": {
@@ -14447,9 +14479,9 @@
 			}
 		},
 		"node_modules/sax": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
-			"integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+			"integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=11.0.0"
@@ -14596,17 +14628,6 @@
 			"dev": true,
 			"license": "MIT",
 			"peer": true
-		},
-		"node_modules/serialize-javascript": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"peer": true,
-			"dependencies": {
-				"randombytes": "^2.1.0"
-			}
 		},
 		"node_modules/serve-index": {
 			"version": "1.9.2",
@@ -15061,9 +15082,9 @@
 			}
 		},
 		"node_modules/spdx-license-ids": {
-			"version": "3.0.22",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
-			"integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+			"version": "3.0.23",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+			"integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
 			"dev": true,
 			"license": "CC0-1.0",
 			"peer": true
@@ -15116,15 +15137,6 @@
 			},
 			"engines": {
 				"node": ">= 6"
-			}
-		},
-		"node_modules/speakingurl": {
-			"version": "14.0.1",
-			"resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
-			"integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/splitpanes": {
@@ -15243,15 +15255,15 @@
 			}
 		},
 		"node_modules/string-width": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.1.tgz",
-			"integrity": "sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+			"integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"get-east-asian-width": "^1.3.0",
-				"strip-ansi": "^7.1.0"
+				"get-east-asian-width": "^1.5.0",
+				"strip-ansi": "^7.1.2"
 			},
 			"engines": {
 				"node": ">=20"
@@ -15275,14 +15287,14 @@
 			}
 		},
 		"node_modules/string-width/node_modules/strip-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"ansi-regex": "^6.0.1"
+				"ansi-regex": "^6.2.2"
 			},
 			"engines": {
 				"node": ">=12"
@@ -15479,9 +15491,9 @@
 			}
 		},
 		"node_modules/stylelint": {
-			"version": "17.3.0",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.3.0.tgz",
-			"integrity": "sha512-1POV91lcEMhj6SLVaOeA0KlS9yattS+qq+cyWqP/nYzWco7K5jznpGH1ExngvPlTM9QF1Kjd2bmuzJu9TH2OcA==",
+			"version": "17.4.0",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.4.0.tgz",
+			"integrity": "sha512-3kQ2/cHv3Zt8OBg+h2B8XCx9evEABQIrv4hh3uXahGz/ZEHrTR80zxBiK2NfXNaSoyBzxO1pjsz1Vhdzwn5XSw==",
 			"dev": true,
 			"funding": [
 				{
@@ -15498,15 +15510,14 @@
 			"dependencies": {
 				"@csstools/css-calc": "^3.1.1",
 				"@csstools/css-parser-algorithms": "^4.0.0",
-				"@csstools/css-syntax-patches-for-csstree": "^1.0.26",
+				"@csstools/css-syntax-patches-for-csstree": "^1.0.27",
 				"@csstools/css-tokenizer": "^4.0.0",
 				"@csstools/media-query-list-parser": "^5.0.0",
 				"@csstools/selector-resolve-nested": "^4.0.0",
 				"@csstools/selector-specificity": "^6.0.0",
-				"balanced-match": "^3.0.1",
 				"colord": "^2.9.3",
 				"cosmiconfig": "^9.0.0",
-				"css-functions-list": "^3.2.3",
+				"css-functions-list": "^3.3.3",
 				"css-tree": "^3.1.0",
 				"debug": "^4.4.3",
 				"fast-glob": "^3.3.3",
@@ -15520,7 +15531,6 @@
 				"import-meta-resolve": "^4.2.0",
 				"imurmurhash": "^0.1.4",
 				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.37.0",
 				"mathml-tag-names": "^4.0.0",
 				"meow": "^14.0.0",
 				"micromatch": "^4.0.8",
@@ -15671,14 +15681,6 @@
 				"stylelint": "^16.8.2 || ^17.0.0"
 			}
 		},
-		"node_modules/stylelint-scss/node_modules/mdn-data": {
-			"version": "2.27.1",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-			"dev": true,
-			"license": "CC0-1.0",
-			"peer": true
-		},
 		"node_modules/stylelint-scss/node_modules/postcss-selector-parser": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
@@ -15780,17 +15782,6 @@
 				"postcss-selector-parser": "^7.1.1"
 			}
 		},
-		"node_modules/stylelint/node_modules/balanced-match": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-3.0.1.tgz",
-			"integrity": "sha512-vjtV3hiLqYDNRoiAv0zC4QaGAMPomEoq83PRmYIofPswwZurCeWR5LByXm7SyoL0Zh5+2z0+HC7jG8gSZJUh0w==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">= 16"
-			}
-		},
 		"node_modules/stylelint/node_modules/file-entry-cache": {
 			"version": "11.1.2",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
@@ -15803,22 +15794,22 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/flat-cache": {
-			"version": "6.1.20",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.20.tgz",
-			"integrity": "sha512-AhHYqwvN62NVLp4lObVXGVluiABTHapoB57EyegZVmazN+hhGhLTn3uZbOofoTw4DSDvVCadzzyChXhOAvy8uQ==",
+			"version": "6.1.21",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.21.tgz",
+			"integrity": "sha512-2u7cJfSf7Th7NxEk/VzQjnPoglok2YCsevS7TSbJjcDQWJPbqUUnSYtriHSvtnq+fRZHy1s0ugk4ApnQyhPGoQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"cacheable": "^2.3.2",
-				"flatted": "^3.3.3",
+				"cacheable": "^2.3.3",
+				"flatted": "^3.4.1",
 				"hookified": "^1.15.0"
 			}
 		},
 		"node_modules/stylelint/node_modules/globby": {
-			"version": "16.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-16.1.0.tgz",
-			"integrity": "sha512-+A4Hq7m7Ze592k9gZRy4gJ27DrXRNnC1vPjxTt1qQxEY8RxagBkBxivkCwg7FxSTG0iLLEMaUx13oOr0R2/qcQ==",
+			"version": "16.1.1",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-16.1.1.tgz",
+			"integrity": "sha512-dW7vl+yiAJSp6aCekaVnVJxurRv7DCOLyXqEG3RYMYUg7AuJ2jCqPkZTA8ooqC2vtnkaMcV5WfFBMuEnTu1OQg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -15917,18 +15908,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/superjson": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
-			"integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
-			"license": "MIT",
-			"dependencies": {
-				"copy-anything": "^4"
-			},
-			"engines": {
-				"node": ">=16"
 			}
 		},
 		"node_modules/supports-color": {
@@ -16093,9 +16072,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.46.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
-			"integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
+			"version": "5.46.1",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
+			"integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"peer": true,
@@ -16113,9 +16092,9 @@
 			}
 		},
 		"node_modules/terser-webpack-plugin": {
-			"version": "5.3.16",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-			"integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
+			"integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -16123,7 +16102,6 @@
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jest-worker": "^27.4.5",
 				"schema-utils": "^4.3.0",
-				"serialize-javascript": "^6.0.2",
 				"terser": "^5.31.1"
 			},
 			"engines": {
@@ -16662,9 +16640,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -17123,16 +17101,16 @@
 			"peer": true
 		},
 		"node_modules/vue": {
-			"version": "3.5.28",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.28.tgz",
-			"integrity": "sha512-BRdrNfeoccSoIZeIhyPBfvWSLFP4q8J3u8Ju8Ug5vu3LdD+yTM13Sg4sKtljxozbnuMu1NB1X5HBHRYUzFocKg==",
+			"version": "3.5.30",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.30.tgz",
+			"integrity": "sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-dom": "3.5.28",
-				"@vue/compiler-sfc": "3.5.28",
-				"@vue/runtime-dom": "3.5.28",
-				"@vue/server-renderer": "3.5.28",
-				"@vue/shared": "3.5.28"
+				"@vue/compiler-dom": "3.5.30",
+				"@vue/compiler-sfc": "3.5.30",
+				"@vue/runtime-dom": "3.5.30",
+				"@vue/server-renderer": "3.5.30",
+				"@vue/shared": "3.5.30"
 			},
 			"peerDependencies": {
 				"typescript": "*"
@@ -17266,14 +17244,14 @@
 			}
 		},
 		"node_modules/vue-router": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.0.2.tgz",
-			"integrity": "sha512-YFhwaE5c5JcJpNB1arpkl4/GnO32wiUWRB+OEj1T0DlDxEZoOfbltl2xEwktNU/9o1sGcGburIXSpbLpPFe/6w==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.0.3.tgz",
+			"integrity": "sha512-nG1c7aAFac7NYj8Hluo68WyWfc41xkEjaR0ViLHCa3oDvTQ/nIuLJlXJX1NUPw/DXzx/8+OKMng045HHQKQKWw==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/generator": "^7.28.6",
 				"@vue-macros/common": "^3.1.1",
-				"@vue/devtools-api": "^8.0.0",
+				"@vue/devtools-api": "^8.0.6",
 				"ast-walker-scope": "^0.8.3",
 				"chokidar": "^5.0.0",
 				"json5": "^2.2.3",
@@ -17432,9 +17410,9 @@
 			}
 		},
 		"node_modules/webdav/node_modules/fast-xml-parser": {
-			"version": "5.3.6",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
-			"integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
+			"version": "5.5.6",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz",
+			"integrity": "sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==",
 			"funding": [
 				{
 					"type": "github",
@@ -17443,6 +17421,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
+				"fast-xml-builder": "^1.1.4",
+				"path-expression-matcher": "^1.1.3",
 				"strnum": "^2.1.2"
 			},
 			"bin": {
@@ -17450,9 +17430,9 @@
 			}
 		},
 		"node_modules/webdav/node_modules/strnum": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-			"integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
+			"integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
 			"funding": [
 				{
 					"type": "github",
@@ -17462,9 +17442,9 @@
 			"license": "MIT"
 		},
 		"node_modules/webpack": {
-			"version": "5.105.2",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
-			"integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
+			"version": "5.105.4",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
+			"integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -17475,11 +17455,11 @@
 				"@webassemblyjs/ast": "^1.14.1",
 				"@webassemblyjs/wasm-edit": "^1.14.1",
 				"@webassemblyjs/wasm-parser": "^1.14.1",
-				"acorn": "^8.15.0",
+				"acorn": "^8.16.0",
 				"acorn-import-phases": "^1.0.3",
 				"browserslist": "^4.28.1",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.19.0",
+				"enhanced-resolve": "^5.20.0",
 				"es-module-lexer": "^2.0.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
@@ -17491,9 +17471,9 @@
 				"neo-async": "^2.6.2",
 				"schema-utils": "^4.3.3",
 				"tapable": "^2.3.0",
-				"terser-webpack-plugin": "^5.3.16",
+				"terser-webpack-plugin": "^5.3.17",
 				"watchpack": "^2.5.1",
-				"webpack-sources": "^3.3.3"
+				"webpack-sources": "^3.3.4"
 			},
 			"bin": {
 				"webpack": "bin/webpack.js"
@@ -17937,14 +17917,13 @@
 			"peer": true
 		},
 		"node_modules/write-file-atomic": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.0.tgz",
-			"integrity": "sha512-YnlPC6JqnZl6aO4uRc+dx5PHguiR9S6WeoLtpxNT9wIG+BDya7ZNE1q7KOjVgaA73hKhKLpVPgJ5QA9THQ5BRg==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+			"integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
 			"dependencies": {
-				"imurmurhash": "^0.1.4",
 				"signal-exit": "^4.0.1"
 			},
 			"engines": {

--- a/src/filesplugin.js
+++ b/src/filesplugin.js
@@ -156,24 +156,24 @@ async function sendFileIdsAfterOAuth(fileIdsStr, currentDir) {
 }
 
 function connectToMattermost(selectedFiles = []) {
-	oauthConnectConfirmDialog(OCA.Mattermost.mattermostUrl).then((result) => {
-		if (result) {
-			if (OCA.Mattermost.usePopup) {
-				oauthConnect(OCA.Mattermost.mattermostUrl, OCA.Mattermost.clientId, null, true)
-					.then((data) => {
-						OCA.Mattermost.mattermostConnected = true
-						openChannelSelector(selectedFiles)
-					})
-			} else {
-				const selectedFilesIds = selectedFiles.map(f => f.id)
-				const currentDirectory = OCA.Mattermost.currentFileList?.folder?.attributes?.filename
-				oauthConnect(
-					OCA.Mattermost.mattermostUrl,
-					OCA.Mattermost.clientId,
-					'files--' + currentDirectory + '--' + selectedFilesIds.join(','),
-				)
-			}
+	oauthConnectConfirmDialog(OCA.Mattermost.mattermostUrl).then(() => {
+		if (OCA.Mattermost.usePopup) {
+			oauthConnect(OCA.Mattermost.mattermostUrl, OCA.Mattermost.clientId, null, true)
+				.then((data) => {
+					OCA.Mattermost.mattermostConnected = true
+					openChannelSelector(selectedFiles)
+				})
+		} else {
+			const selectedFilesIds = selectedFiles.map(f => f.id)
+			const currentDirectory = OCA.Mattermost.currentFileList?.folder?.attributes?.filename
+			oauthConnect(
+				OCA.Mattermost.mattermostUrl,
+				OCA.Mattermost.clientId,
+				'files--' + currentDirectory + '--' + selectedFilesIds.join(','),
+			)
 		}
+	}).catch((error) => {
+		console.debug('Oauth error', error)
 	})
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 import { generateUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'
-import { showError } from '@nextcloud/dialogs'
+import { DialogBuilder, showError } from '@nextcloud/dialogs'
 import FileOutlineIcon from 'vue-material-design-icons/FileOutline.vue'
 import OpenInNewIcon from 'vue-material-design-icons/OpenInNew.vue'
 import LinkVariantIcon from 'vue-material-design-icons/LinkVariant.vue'
@@ -63,60 +63,62 @@ export function oauthConnect(mattermostUrl, clientId, oauthOrigin, usePopup = fa
 
 export function oauthConnectConfirmDialog(mattermostUrl) {
 	return new Promise((resolve, reject) => {
-		const settingsLink = generateUrl('/settings/user/connected-accounts')
-		const linkText = t('integration_mattermost', 'Connected accounts')
-		const settingsHtmlLink = `<a href="${settingsLink}" class="external">${linkText}</a>`
-		OC.dialogs.message(
-			t('integration_mattermost', 'You need to connect before using the Mattermost integration.')
-			+ '<br><br>'
-			+ t('integration_mattermost', 'Do you want to connect to {mmUrl}?', { mmUrl: mattermostUrl })
-			+ '<br><br>'
-			+ t(
-				'integration_mattermost',
-				'You can choose another Mattermost server in the {settingsHtmlLink} section of your personal settings.',
-				{ settingsHtmlLink },
-				null,
-				{ escape: false },
-			),
-			t('integration_mattermost', 'Connect to Mattermost'),
-			'none',
-			{
-				type: OC.dialogs.YES_NO_BUTTONS,
-				confirm: t('integration_mattermost', 'Connect'),
-				confirmClasses: 'success',
-				cancel: t('integration_mattermost', 'Cancel'),
-			},
-			(result) => {
-				resolve(result)
-			},
-			true,
-			true,
-		)
+		new DialogBuilder()
+			.setName(t('integration_mattermost', 'Connect to Mattermost'))
+			.setText(
+				t('integration_mattermost', 'You need to connect to a Mattermost server before using the Mattermost integration.')
+				+ ' --- '
+				+ t('integration_mattermost', 'You can choose another Mattermost server in the "Mattermost" section of your personal settings.')
+				+ ' --- '
+				+ t('integration_mattermost', 'Do you want to connect to {mmUrl}?', { mmUrl: mattermostUrl }),
+			)
+			.setButtons([
+				{
+					label: t('integration_mattermost', 'Cancel'),
+					variant: 'secondary',
+					callback: () => {
+						reject(new Error('OAuth connection canceled'))
+					},
+				},
+				{
+					label: t('integration_mattermost', 'Connect'),
+					variant: 'primary',
+					callback: () => {
+						resolve()
+					},
+				},
+			])
+			.build()
+			.show()
 	})
 }
 
 export function gotoSettingsConfirmDialog() {
 	const settingsLink = generateUrl('/settings/user/connected-accounts')
-	OC.dialogs.message(
-		t('integration_mattermost', 'You need to connect to a Mattermost server before using the Mattermost integration.')
-		+ '<br><br>'
-		+ t('integration_mattermost', 'Do you want to go to your "Connect accounts" personal settings?'),
-		t('integration_mattermost', 'Connect to Mattermost'),
-		'none',
-		{
-			type: OC.dialogs.YES_NO_BUTTONS,
-			confirm: t('integration_mattermost', 'Go to settings'),
-			confirmClasses: 'success',
-			cancel: t('integration_mattermost', 'Cancel'),
-		},
-		(result) => {
-			if (result) {
-				window.location.replace(settingsLink)
-			}
-		},
-		true,
-		true,
-	)
+	new DialogBuilder()
+		.setName(t('integration_mattermost', 'Connect to Mattermost'))
+		.setText(
+			t('integration_mattermost', 'You need to connect to a Mattermost server before using the Mattermost integration.')
+			+ ' --- '
+			+ t('integration_mattermost', 'Do you want to go to your "Connected accounts" personal settings?'),
+		)
+		.setButtons([
+			{
+				label: t('integration_mattermost', 'Cancel'),
+				variant: 'secondary',
+				callback: () => {
+				},
+			},
+			{
+				label: t('integration_mattermost', 'Go to settings'),
+				variant: 'primary',
+				callback: () => {
+					window.location.replace(settingsLink)
+				},
+			},
+		])
+		.build()
+		.show()
 }
 
 export function humanFileSize(bytes, approx = false, si = false, dp = 1) {


### PR DESCRIPTION
While testing if the UI issue reported in https://github.com/nextcloud/assistant/issues/418 was affecting the modals in this apps, I spotted it was broken because we still use the old `OC.dialogs.message` which was removed in NC 34.

* Replace broken `OC.dialogs.message` by DialogBuilder from @nextcloud/dialogs
* Update npm pkgs