### PR TITLE
Prepare v3.1.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/appinfo/info.xml    @kyteinsky @bigcat88
+/appinfo/info.xml    @janepie @kyteinsky 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+
+## 3.1.0 – 2026-04-16
+
+### Added
+- Support for NC34 @julien-nc [#106](https://github.com/nextcloud/integration_mattermost/pull/106)
+
+### Changed
+- updated dependencies
+
+### Fixed
+- No more FileAction class in @nextcloud/files @julien-nc [#106](https://github.com/nextcloud/integration_mattermost/pull/106)
+- small UI issues @julien-nc [#114](https://github.com/nextcloud/integration_mattermost/pull/114)
+
+
+
 ## 3.0.0 – 2025-12-23
 
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<summary>Integration of Mattermost</summary>
 	<description><![CDATA[Mattermost integration provides a dashboard widget displaying your most important notifications
 and a unified search provider for messages. It also lets you send files to Mattermost from Nextcloud Files.]]></description>
-	<version>3.0.0</version>
+	<version>3.1.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Mattermost</namespace>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "integration_mattermost",
-	"version": "3.0.0",
+	"version": "3.1.0",
 	"description": "Mattermost integration",
 	"main": "index.js",
 	"directories": {


### PR DESCRIPTION
### Added
- Support for NC34 @julien-nc [#106](https://github.com/nextcloud/integration_mattermost/pull/106)

### Changed
- updated dependencies

### Fixed
- No more FileAction class in @nextcloud/files @julien-nc [#106](https://github.com/nextcloud/integration_mattermost/pull/106)
- small UI issues @julien-nc [#114](https://github.com/nextcloud/integration_mattermost/pull/114)